### PR TITLE
Doc: Edge() initializer also accepts Node objects for src and dst.

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -841,8 +841,11 @@ class Edge(object,  Common ):
     
     edge(src, dst, attribute=value, ...)
     
-    src: source node's name
-    dst: destination node's name
+    src: source node
+    dst: destination node
+
+    `src` and `dst` can be specified as a `Node` object or as the
+    node's name string.
     
     All the attributes defined in the Graphviz dot language should
     be supported.


### PR DESCRIPTION
A minor addition to documentation, triggered by comments at http://stackoverflow.com/questions/6953957/edges-between-two-subgraphs-in-pydot