### PR TITLE
Hardcode revision number

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -1,4 +1,4 @@
-# -*- coding: Latin-1 -*-
+# -*- coding: utf-8 -*-
 """Graphviz's dot language Python interface.
 
 This module provides with a full interface to create handle modify
@@ -17,9 +17,9 @@ Copyright (c) 2005-2011 Ero Carrera <ero.carrera@gmail.com>
 Distributed under MIT license [http://opensource.org/licenses/mit-license.html].
 """
 
-__revision__ = "$LastChangedRevision$"
+__revision__ = 28
 __author__ = 'Ero Carrera'
-__version__ = '1.0.%d' % int( __revision__[21:-2] )
+__version__ = '1.0.%d' % __revision__
 __license__ = 'MIT'
 
 import os


### PR DESCRIPTION
Since the repo was moved from SVN on google code to github, `$LastChangedRevision$` doesn't get replaced with an actual revision number.