### PR TITLE
Add an encoding parameter to write_* and create_* functions

### DIFF
--- a/test/pydot_unittest.py
+++ b/test/pydot_unittest.py
@@ -192,7 +192,7 @@ class TestGraphAPI(unittest.TestCase):
         c = pydot.graph_from_dot_file(filename, encoding=encoding)
         sha = ''
         for g in c:
-            jpe_data = g.create(format='jpe')
+            jpe_data = g.create(format='jpe', encoding=encoding)
             sha += sha256(jpe_data).hexdigest()
         return sha
 


### PR DESCRIPTION
Add an encoding parameter to `write_*` and `create_*` functions so that dot files created will be written in the specified encoding. This includes the temporary dot files created when writing or outputting in other formats.

Fixes issue #142. 

