### PR TITLE
Quote when necessary also for clusters

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -1635,7 +1635,7 @@ class Cluster(Graph):
         if obj_dict is None:
 
             self.obj_dict['type'] = 'subgraph'
-            self.obj_dict['name'] = 'cluster_'+graph_name
+            self.obj_dict['name'] = quote_if_necessary('cluster_'+graph_name)
 
         self.create_attribute_methods(CLUSTER_ATTRIBUTES)
 


### PR DESCRIPTION
It is odd (and a problem for my usage) that cluster names are not quoted when necessary while it is done for graphs, node, edge, etc.