### PR TITLE
Changed exception class to be more descriptive for graphviz installation errors

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -1878,9 +1878,9 @@ class Dot(Graph):
                 stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         except OSError as e:
             if e.errno == os.errno.ENOENT:
-                raise FileNotFoundError(
-                    '"{prog}" not found in path.'.format(
-                        prog=prog))
+                e.args = e.args + (
+                    '"{prog}" not found in path.'.format(prog=prog),)
+                raise OSError(*e.args)
             else:
                 raise
         stdout_data, stderr_data = p.communicate()

--- a/pydot.py
+++ b/pydot.py
@@ -1878,7 +1878,7 @@ class Dot(Graph):
                 stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         except OSError as e:
             if e.errno == os.errno.ENOENT:
-                raise Exception(
+                raise FileNotFoundError(
                     '"{prog}" not found in path.'.format(
                         prog=prog))
             else:


### PR DESCRIPTION
pydot raises a generic `Exception` when it can't find graphviz installation binaries, which is not ideal. This pull request changes that to a more descriptive and specific class of exception so that it can be handled properly by other code (see https://github.com/fchollet/keras/pull/6398 for the specific motivation).