### PR TITLE
Propagate LD_LIBRARY_PATH when calling graphviz

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -1868,6 +1868,7 @@ class Dot(Graph):
         # with `shell=False`
         env = dict()
         env['PATH'] = os.environ['PATH']
+        env['LD_LIBRARY_PATH'] = os.environ.get('LD_LIBRARY_PATH', '')
         cmdline = [prog, '-T' + format] + args + [tmp_name]
         try:
             p = subprocess.Popen(


### PR DESCRIPTION
Since [v1.2.0](https://github.com/erocarrera/pydot/commit/bc639e76b214b1795ebd6263680ee55d9d4fca9f#diff-44fda7721399b25e8cb06471016a3454L1942) `pydot` fails when used with a installation of graphviz which requires `LD_LIBRARY_PATH` to be set appropriately. This PR re-enables the propagation of `LD_LIBRARY_PATH` to the subprocess.

I'm not sure if any other variables should be included? The other main one that I can think of is `DYLD_LIBRARY_PATH`.