### PR TITLE
CI: Replace 3.7-dev with 3.7 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,13 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
+
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 addons:
   apt:


### PR DESCRIPTION
`3.7-dev` is an old alpha version (`3.7.0a4+`) that hasn't been updated for a long time.

Python 3.7.0 final was released on 2018-06-27, so let's use that instead.

It needs a little workaround on Travis, see https://github.com/travis-ci/travis-ci/issues/9815.